### PR TITLE
feat: add CZ_HUB_URL secret to orchestrator

### DIFF
--- a/charts/codezero/templates/orchestrator/secret.yaml
+++ b/charts/codezero/templates/orchestrator/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "orchestrator.fullname" . }}
+data:
+  {{- if .Values.codezero.hub.url }}
+  CZ_HUB_URL: {{ .Values.codezero.hub.url | b64enc }}
+  {{- end }}


### PR DESCRIPTION
Adds CZ_HUB_URL to orchestrator, needed to fetch space plan data