### PR TITLE
chore: adds init-containers to loadbalancer and orchestrator

### DIFF
--- a/charts/codezero/templates/lb/deployment.yaml
+++ b/charts/codezero/templates/lb/deployment.yaml
@@ -19,6 +19,14 @@ spec:
       serviceAccountName: {{ include "lb.name" . }}
       securityContext:
         {{- toYaml .Values.lb.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-cert
+          image: public.ecr.aws/docker/library/busybox:1.36
+          command: ["sh", "-c", "for i in {1..30}; do sleep 1; if [ -e /etc/ssl/certs/space/server.pem ]; then exit 0; fi; done; exit 1"]
+          volumeMounts:
+            - mountPath: /etc/ssl/certs/space
+              name: space-cert
+              readOnly: true
       containers:
         - name: {{ include "lb.name" . }}
           securityContext:

--- a/charts/codezero/templates/orchestrator/deployment.yaml
+++ b/charts/codezero/templates/orchestrator/deployment.yaml
@@ -19,6 +19,14 @@ spec:
       serviceAccountName: {{ include "orchestrator.name" . }}
       securityContext:
         {{- toYaml .Values.orchestrator.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-cert
+          image: public.ecr.aws/docker/library/busybox:1.36
+          command: ["sh", "-c", "for i in {1..30}; do sleep 1; if [ -e /etc/ssl/certs/space/ca.pem ]; then exit 0; fi; done; exit 1"]
+          volumeMounts:
+            - mountPath: /etc/ssl/certs/space
+              name: space-cert
+              readOnly: true
       containers:
         - name: {{ include "orchestrator.name" . }}
           securityContext:


### PR DESCRIPTION
## Description

Adds simple init-containers to loadbalancer and orchestrator. Both app containers require published secrets in `space-cert` to start up properly or they go into CrashloopBackoff until the `space-cert` secret has been published by the `system` pod. If the file does not exist within 30 seconds the pod will go into error on the init container.

This makes for a strange race conditions between system pod and the rest of the pods. Especially since there is a circular dependency between `system` and `orchestrator`. This should make the depedencies and the startup procedure much clearer.

Next steps are to make two init-container for `system` where the first is registering the space and the second is waiting for orchestrator to be up. Then we can remove that responsibility from the `system` app and also remove that [weirdo code](https://github.com/c6o/codezero/blob/a618acb92b6080df3dc9f87ea5b67dd402d214a4/apps/system/spaceregister/spaceregister.go#L102) where `system` does a restart/rollout of the codezero namespace.

Describe of orchestrator pod after the change:
<img width="1363" alt="Screenshot 2024-03-26 at 3 16 24 PM" src="https://github.com/c6o/helm-charts/assets/469886/7d3b4944-8e27-4714-b2ee-c5aa475c6911">

