### PR TITLE
Add init containers for system

### DIFF
--- a/charts/codezero/templates/system/deployment.yaml
+++ b/charts/codezero/templates/system/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         {{- toYaml .Values.system.podSecurityContext | nindent 8 }}
       initContainers:
         - name: space-init
-          image: "c6oio/spaceinit:e726047"
+          image: "c6oio/spaceinit:6937d6c"
           imagePullPolicy: {{ .Values.system.image.pullPolicy }}
           env:
             - name: CZ_CLUSTER_CERT

--- a/charts/codezero/templates/system/deployment.yaml
+++ b/charts/codezero/templates/system/deployment.yaml
@@ -20,8 +20,8 @@ spec:
       securityContext:
         {{- toYaml .Values.system.podSecurityContext | nindent 8 }}
       initContainers:
-        - name: register-space
-          image: "c6oio/spaceinit:a5962c2"
+        - name: space-init
+          image: "c6oio/spaceinit:955bf44"
           imagePullPolicy: {{ .Values.system.image.pullPolicy }}
           env:
             - name: CZ_CLUSTER_CERT
@@ -41,7 +41,7 @@ spec:
               readOnly: true
         - name: wait-for-orchestrator
           image: public.ecr.aws/docker/library/busybox:1.36
-          command: ["sh", "-c", "for i in {1..30}; do if wget --spider --quiet 'http://orchestrator:8900'; then exit 0; fi; sleep 0.5; done; exit 1"]
+          command: ["sh", "-c", "for i in {1..20}; do if wget --spider --quiet 'http://orchestrator:8900'; then exit 0; fi; sleep 0.5; done; exit 1"]
       containers:
         - name: {{ include "system.name" . }}
           securityContext:

--- a/charts/codezero/templates/system/deployment.yaml
+++ b/charts/codezero/templates/system/deployment.yaml
@@ -26,8 +26,6 @@ spec:
           env:
             - name: CZ_CLUSTER_CERT
               value: /etc/ssl/certs/space/tls.pem
-            - name: CZ_CLUSTER_CERT_KEY
-              value: /etc/ssl/certs/space/tls.key
             {{- if .Values.hub.url }}
             - name: CZ_HUB_URL
               value: {{ .Values.hub.url }}

--- a/charts/codezero/templates/system/deployment.yaml
+++ b/charts/codezero/templates/system/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               readOnly: true
         - name: wait-for-orchestrator
           image: public.ecr.aws/docker/library/busybox:1.36
-          command: ["sh", "-c", "for i in {1..20}; do if wget --spider --quiet 'http://orchestrator:8900'; then exit 0; fi; sleep 0.5; done; exit 1"]
+          command: ["sh", "-c", "for i in `seq 1 60`; do if wget --spider --quiet 'http://orchestrator:8900'; then exit 0; fi; sleep 0.5; done; exit 1"]
       containers:
         - name: {{ include "system.name" . }}
           securityContext:

--- a/charts/codezero/templates/system/deployment.yaml
+++ b/charts/codezero/templates/system/deployment.yaml
@@ -19,6 +19,29 @@ spec:
       serviceAccountName: {{ include "system.name" . }}
       securityContext:
         {{- toYaml .Values.system.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: register-space
+          image: "c6oio/spaceinit:a5962c2"
+          imagePullPolicy: {{ .Values.system.image.pullPolicy }}
+          env:
+            - name: CZ_CLUSTER_CERT
+              value: /etc/ssl/certs/space/tls.pem
+            - name: CZ_CLUSTER_CERT_KEY
+              value: /etc/ssl/certs/space/tls.key
+            {{- if .Values.hub.url }}
+            - name: CZ_HUB_URL
+              value: {{ .Values.hub.url }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "system.name" . }}
+          volumeMounts:
+            - mountPath: /etc/ssl/certs/space
+              name: space-cert
+              readOnly: true
+        - name: wait-for-orchestrator
+          image: public.ecr.aws/docker/library/busybox:1.36
+          command: ["sh", "-c", "for i in {1..30}; do if wget --spider --quiet 'http://orchestrator:8900'; then exit 0; fi; sleep 0.5; done; exit 1"]
       containers:
         - name: {{ include "system.name" . }}
           securityContext:

--- a/charts/codezero/templates/system/deployment.yaml
+++ b/charts/codezero/templates/system/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         {{- toYaml .Values.system.podSecurityContext | nindent 8 }}
       initContainers:
         - name: space-init
-          image: "c6oio/spaceinit:955bf44"
+          image: "c6oio/spaceinit:e726047"
           imagePullPolicy: {{ .Values.system.image.pullPolicy }}
           env:
             - name: CZ_CLUSTER_CERT


### PR DESCRIPTION
## Description

adds init-container for system. Image for init-container pinned to sha of [PR merge](https://github.com/c6o/codezero/commit/e726047a04797fcbea6064b0bca8412f17df0402)

With this in place we will have 0 restarts of containers unless the registration fails or system can't reach orchestrator.

This is safe to release since old system apps have an early exist condition when the cert file exists.
