### PR TITLE
fix: busybox does not support brace expressions

### DIFF
--- a/charts/codezero/templates/lb/deployment.yaml
+++ b/charts/codezero/templates/lb/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       initContainers:
         - name: wait-for-cert
           image: public.ecr.aws/docker/library/busybox:1.36
-          command: ["sh", "-c", "for i in {1..30}; do sleep 1; if [ -e /etc/ssl/certs/space/server.pem ]; then exit 0; fi; done; exit 1"]
+          command: ["sh", "-c", "for i in `seq 1 60`; do sleep 0.5; if [ -e /etc/ssl/certs/space/server.pem ]; then exit 0; fi; done; exit 1"]
           volumeMounts:
             - mountPath: /etc/ssl/certs/space
               name: space-cert

--- a/charts/codezero/templates/orchestrator/deployment.yaml
+++ b/charts/codezero/templates/orchestrator/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       initContainers:
         - name: wait-for-cert
           image: public.ecr.aws/docker/library/busybox:1.36
-          command: ["sh", "-c", "for i in {1..30}; do sleep 1; if [ -e /etc/ssl/certs/space/ca.pem ]; then exit 0; fi; done; exit 1"]
+          command: ["sh", "-c", "for i in `seq 1 60`; do sleep 0.5; if [ -e /etc/ssl/certs/space/ca.pem ]; then exit 0; fi; done; exit 1"]
           volumeMounts:
             - mountPath: /etc/ssl/certs/space
               name: space-cert


### PR DESCRIPTION
## Description

Fixes init-containers looping by using `seq` as busybox does not support brace expressions. Will fix init containers to go into crashloop as the container currently checks for the file only once but will eventually pass through standard crashloop backoff.