### PR TITLE
feat: replace cluster-admin role

### DIFF
--- a/charts/codezero/templates/rbac.yaml
+++ b/charts/codezero/templates/rbac.yaml
@@ -1,15 +1,75 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "codezero.name" . }}-binding
+  name: {{ include "codezero.name" . }}-system-cluster-binding
 subjects:
-- kind: ServiceAccount
-  name: {{ include "orchestrator.name" . }}
-  namespace: {{ .Release.Namespace }}
 - kind: ServiceAccount
   name: {{ include "system.name" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: cluster-admin
+  name: system-clusterrole
   apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system-clusterrole
+rules:
+- apiGroups: [""]
+  resources: ["services", "pods"]
+  verbs: ["get", "watch", "list", "patch", "create", "delete"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "codezero.name" . }}-system-binding
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "system.name" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: system-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "codezero.name" . }}-orchestrator-binding
+subjects:
+- kind: ServiceAccount
+  name: {{ include "orchestrator.name" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: orchestrator-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orchestrator-clusterrole
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Description

Defines the minimal access our pods require broken down by orchestrator and system.

system: 
- needs cluster role to do anything with pods and services and read endpoint slices
- needs to patch secret and configmap for space initialization in our namespace

orchestrator:
- needs cluster role to read namespaces
