### PR TITLE
create new version of helm chart pointing images to 2.2.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,7 @@ jobs:
           project_id: c6o-production
       - name: Deploy
         run: |
+          curl https://storage.googleapis.com/c6o-releases/helm-charts/index.yaml --output ./index.yaml
           helm package ./charts/* -d ./tmp/
-          helm repo index tmp --url https://charts.codezero.io
+          helm repo index tmp --url https://charts.codezero.io --merge ./index.yaml
           gsutil cp ./tmp/* gs://c6o-releases/helm-charts

--- a/charts/codezero/Chart.yaml
+++ b/charts/codezero/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2"
+appVersion: "2.2.0"

--- a/charts/codezero/templates/system/deployment.yaml
+++ b/charts/codezero/templates/system/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         {{- toYaml .Values.system.podSecurityContext | nindent 8 }}
       initContainers:
         - name: space-init
-          image: "c6oio/spaceinit:825a485"
+          image: "c6oio/spaceinit:{{ default .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.system.image.pullPolicy }}
           env:
             - name: CZ_CLUSTER_CERT

--- a/charts/codezero/values.yaml
+++ b/charts/codezero/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  tag: pasley
+  tag: 4786a5b
 hub:
   url: https://hub.codezero.io
 space:


### PR DESCRIPTION
## Description

New chart version that pins image tags to current 2.2.0. Changes `publish` workflow to add new versions to index.yaml
