### PR TITLE
chore: change publish workflow to tag push event

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,8 @@
 name: publish
 on:
   push:
-    branches:
-      - pasley
+    tags:
+      - '0*'
   workflow_dispatch:
 jobs:
   publish:


### PR DESCRIPTION
## Description

Start publishing helm charts on git tag push events instead of branch merges
