### PR TITLE
chore: allow setting annotations

### DIFF
--- a/charts/codezero/templates/lb/service.yaml
+++ b/charts/codezero/templates/lb/service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "codezero.name" . }}
   labels:
     {{- include "lb.labels" . | nindent 4 }}
+  annotations:
+    {{ toYaml .Values.lb.service.annotations | indent 4 | trim}}
 spec:
   type: {{ .Values.lb.service.type }}
   ports:

--- a/charts/codezero/values.yaml
+++ b/charts/codezero/values.yaml
@@ -97,4 +97,5 @@ lb:
     name: ""
 
   service:
+    annotations: { }
     type: LoadBalancer


### PR DESCRIPTION
## Description

Allows adding annotations to the K8 service for the load balancer. E.g adding AWS specific annotations.