### PR TITLE
feat: adds needed configuration to create a teamspace on helm install codezero

### DIFF
--- a/charts/codezero/templates/configmap.yaml
+++ b/charts/codezero/templates/configmap.yaml
@@ -1,9 +1,16 @@
 
-{{- define "codezero.spaceID" -}}
+{{- if and (ne .Values.org.apikey "") (eq .Values.space.name "") (.Release.IsInstall) }}
+{{- fail "A Values.space.name is required" }}
+{{- end }}
+
+{{- define "codezero.configmap" -}}
 {{- $existingCM := lookup "v1" "ConfigMap" .Release.Namespace (include "codezero.name" .) -}}
 {{- if $existingCM -}}
 {{ $existingCM.data | toYaml }}
 {{- else -}}
+{{- if .Values.space.name }}
+spaceName: {{ .Values.space.name }}
+{{- end }}
 spaceID: ""
 {{- end -}}
 {{- end -}}
@@ -14,4 +21,4 @@ kind: ConfigMap
 metadata:
   name: {{ include "codezero.name" . }}
 data:
-{{ include "codezero.spaceID" . | indent 2 -}}
+{{ include "codezero.configmap" . | indent 2 -}}

--- a/charts/codezero/templates/system/deployment.yaml
+++ b/charts/codezero/templates/system/deployment.yaml
@@ -30,6 +30,12 @@ spec:
             - name: CZ_HUB_URL
               value: {{ .Values.hub.url }}
             {{- end }}
+            - name: CZ_HUB_SPACE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "codezero.name" . }}
+                  key: spaceName
+                  optional: true
           envFrom:
             - secretRef:
                 name: {{ include "system.name" . }}

--- a/charts/codezero/templates/system/secret.yaml
+++ b/charts/codezero/templates/system/secret.yaml
@@ -1,14 +1,25 @@
-{{- if and (eq .Values.space.token "") (.Release.IsInstall) }}
-{{- fail "A Values.token is required" }}
+{{- if and (eq .Values.space.token "") (eq .Values.org.apikey "") (.Release.IsInstall) }}
+{{- fail "A Values.space.token or Values.org.apikey is required" }}
 {{- end }}
 
+{{- if and (ne .Values.org.apikey "") (eq .Values.org.id "") (.Release.IsInstall) }}
+{{- fail "A Values.org.id is required" }}
+{{- end }}
 
-{{- define "codezero.spaceToken" -}}
+{{- define "codezero.secrets" -}}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "system.name" .) -}}
 {{- if $existingSecret -}}
 {{ $existingSecret.data | toYaml }}
 {{- else -}}
+{{- if .Values.space.token }}
 CZ_HUB_SPACE_TOKEN: {{ .Values.space.token | b64enc }}
+{{- end }}
+{{- if .Values.org.id }}
+CZ_HUB_ORG_ID: {{ .Values.org.id | b64enc }}
+{{- end }}
+{{- if .Values.org.apikey }}
+CZ_HUB_ORG_APIKEY: {{ .Values.org.apikey | b64enc }}
+{{- end }}
 {{- end -}}
 {{- end -}}
 
@@ -18,4 +29,4 @@ kind: Secret
 metadata:
   name: {{ include "system.name" . }}
 data:
-{{ include "codezero.spaceToken" . | indent 2 -}}
+{{ include "codezero.secrets" . | indent 2 -}}

--- a/charts/codezero/values.yaml
+++ b/charts/codezero/values.yaml
@@ -8,6 +8,10 @@ hub:
   url: https://hub.codezero.io
 space:
   token: ""
+  name: ""
+org:
+  apikey: ""
+  id: ""
 
 podAnnotations: { }
 labels: { }


### PR DESCRIPTION
Adds required values to create the teamspace while CodeZero is installed in the cluster.

Added values:
- space.name
- org.id
- org.apikey

These values are stored in:
- codezero.configmap: 
  - space.name
- codezero.secrets:
  - org.id
  - org.apikey

And are used by the system's init container.
