### PR TITLE
fix: adds security context to init containers; change default to compliant restricted policy

### DIFF
--- a/charts/codezero/templates/lb/deployment.yaml
+++ b/charts/codezero/templates/lb/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         {{- toYaml .Values.lb.podSecurityContext | nindent 8 }}
       initContainers:
         - name: wait-for-cert
+          securityContext:
+            {{- toYaml .Values.lb.securityContext | nindent 12 }}
           image: public.ecr.aws/docker/library/busybox:1.36
           command: ["sh", "-c", "for i in `seq 1 20`; do sleep 0.5; if [ -e /etc/ssl/certs/space/server.pem ]; then exit 0; fi; done; exit 1"]
           volumeMounts:

--- a/charts/codezero/templates/orchestrator/deployment.yaml
+++ b/charts/codezero/templates/orchestrator/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         {{- toYaml .Values.orchestrator.podSecurityContext | nindent 8 }}
       initContainers:
         - name: wait-for-cert
+          securityContext:
+            {{- toYaml .Values.orchestrator.securityContext | nindent 12 }}
           image: public.ecr.aws/docker/library/busybox:1.36
           command: ["sh", "-c", "for i in `seq 1 20`; do sleep 0.5; if [ -e /etc/ssl/certs/space/ca.pem ]; then exit 0; fi; done; exit 1"]
           volumeMounts:

--- a/charts/codezero/templates/system/deployment.yaml
+++ b/charts/codezero/templates/system/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         {{- toYaml .Values.system.podSecurityContext | nindent 8 }}
       initContainers:
         - name: space-init
+          securityContext:
+            {{- toYaml .Values.system.securityContext | nindent 12 }}
           image: "c6oio/spaceinit:{{ default .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.system.image.pullPolicy }}
           env:
@@ -44,6 +46,8 @@ spec:
               name: space-cert
               readOnly: true
         - name: wait-for-orchestrator
+          securityContext:
+            {{- toYaml .Values.system.securityContext | nindent 12 }}
           image: public.ecr.aws/docker/library/busybox:1.36
           command: ["sh", "-c", "for i in `seq 1 60`; do if wget --spider --quiet 'http://orchestrator:8900'; then exit 0; fi; sleep 0.5; done; exit 1"]
       containers:

--- a/charts/codezero/values.yaml
+++ b/charts/codezero/values.yaml
@@ -32,7 +32,16 @@ system:
   podLabels: { }
 
   podSecurityContext: { }
-  securityContext: { }
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    allowPrivilegeEscalation: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
 
   resources: { }
   nodeSelector: { }
@@ -56,7 +65,16 @@ orchestrator:
   podLabels: { }
 
   podSecurityContext: { }
-  securityContext: { }
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    allowPrivilegeEscalation: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
 
   resources: { }
   nodeSelector: { }
@@ -89,8 +107,6 @@ lb:
     capabilities:
       drop:
         - ALL
-      add:
-        - NET_BIND_SERVICE
     seccompProfile:
       type: RuntimeDefault
 


### PR DESCRIPTION
## Description

Set `securityContext` for init-containers. Sets all security contexts to a compliant [restricted policy](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted). Remove `NET_BIND_SERVICE` for loadbalancer deployment as we are not binding to privileged ports