### PR TITLE
chore: upload with cache-control

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,4 +29,4 @@ jobs:
           curl https://storage.googleapis.com/c6o-releases/helm-charts/index.yaml --output ./index.yaml
           helm package ./charts/* -d ./tmp/
           helm repo index tmp --url https://charts.codezero.io --merge ./index.yaml
-          gsutil cp ./tmp/* gs://c6o-releases/helm-charts
+          gsutil -h Cache-Control:"Cache-Control:public, max-age=60" cp ./tmp/* gs://c6o-releases/helm-charts


### PR DESCRIPTION
## Description

Prevent helm charts to be cached for an hour

https://cloud.google.com/storage/docs/caching#built-in_caching_for
