### PR TITLE
feat: allow system to create router pods with privileged access

### DIFF
--- a/charts/codezero/templates/system/deployment.yaml
+++ b/charts/codezero/templates/system/deployment.yaml
@@ -79,6 +79,8 @@ spec:
               value: "8800"
             - name: CZ_ROUTER_IMAGE
               value: "c6oio/router:{{ .Values.system.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
+            - name: CZ_ROUTER_PRIVILEGED_ACCESS
+              value: "{{ .Values.system.router.privilegedAccess }}"
           envFrom:
             - secretRef:
                 name: {{ include "system.name" . }}

--- a/charts/codezero/values.yaml
+++ b/charts/codezero/values.yaml
@@ -31,6 +31,8 @@ system:
   labels: { }
   podLabels: { }
 
+  router:
+    privilegedAccess: false
   podSecurityContext: { }
   securityContext:
     runAsNonRoot: true


### PR DESCRIPTION
## Description

Allow system to create router pods with privileged access when restricted policy does not allow binding to privileged ports. Current restricted policy does add the capability of `NET_BIND_SERVICE` but this is not guaranteed to work on all clusters.
