### PR TITLE
chore: move router values to top level

### DIFF
--- a/charts/codezero/templates/system/deployment.yaml
+++ b/charts/codezero/templates/system/deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: CZ_ROUTER_IMAGE
               value: "c6oio/router:{{ .Values.system.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
             - name: CZ_ROUTER_PRIVILEGED_ACCESS
-              value: "{{ .Values.system.router.privilegedAccess }}"
+              value: "{{ .Values.router.privilegedAccess }}"
           envFrom:
             - secretRef:
                 name: {{ include "system.name" . }}

--- a/charts/codezero/values.yaml
+++ b/charts/codezero/values.yaml
@@ -20,6 +20,9 @@ podAnnotations: { }
 labels: { }
 podLabels: { }
 
+router:
+  privilegedAccess: false
+
 system:
   name: system
   image:
@@ -31,8 +34,6 @@ system:
   labels: { }
   podLabels: { }
 
-  router:
-    privilegedAccess: false
   podSecurityContext: { }
   securityContext:
     runAsNonRoot: true


### PR DESCRIPTION
## Description

Follow up from #43. By moving the router values outside of system customers don't need to modify their configs when we make internal changes.