### PR TITLE
chore: increase haproxy timeouts to an hour

### DIFF
--- a/charts/codezero/templates/lb/configmap.yaml
+++ b/charts/codezero/templates/lb/configmap.yaml
@@ -12,9 +12,9 @@ data:
 
     defaults
       log global
-      timeout client 60s
       timeout connect 60s
-      timeout server 60s
+      timeout client 3600s
+      timeout server 3600s
 
     frontend system
       bind :8800 ssl crt /etc/ssl/certs/space/server.pem


### PR DESCRIPTION
## Description

Allows connectrpc connections to live for an hour
