### PR TITLE
chore: use secret for redis

### DIFF
--- a/charts/codezero/templates/secret.yaml
+++ b/charts/codezero/templates/secret.yaml
@@ -1,4 +1,3 @@
-# I'm not sure why this is safe for both install and
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/codezero/templates/spaceagent/deployment.yaml
+++ b/charts/codezero/templates/spaceagent/deployment.yaml
@@ -62,7 +62,15 @@ spec:
             - name: CZ_SCALING_ENABLED
               value: "true"
             - name: CZ_REDIS_HOST
-              value: "{{ .Values.spaceagent.redis.host }}"
+              valueFrom:
+                secretKeyRef:
+                  name: redis
+                  key: host
+            - name: CZ_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis
+                  key: password
             {{- end }}
           envFrom:
             - secretRef:
@@ -93,6 +101,12 @@ spec:
           secret:
             secretName: space-cert
             optional: true
+        {{- if gt .Values.spaceagent.replicas 1.0}}
+        - name: redis
+          secret:
+            secretName: {{ .Values.spaceagent.redis.secret }}
+            optional: true
+        {{- end }}
       {{- with .Values.spaceagent.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/codezero/values.yaml
+++ b/charts/codezero/values.yaml
@@ -60,9 +60,9 @@ spaceagent:
     pullPolicy: Always
   replicas: 1
 
-  # for horizontal scaling (experimental)
+  # for horizontal scaling (experimental). Secret must be in the same namespace as the spaceagent
   redis:
-    host: ""
+    secret: ""
 
   podAnnotations: { }
   labels: { }


### PR DESCRIPTION
## Description

Use secret for redis instead of plain env variables so passwords can be set properly.
