### PR TITLE
feat: add topology spread contraints

### DIFF
--- a/charts/codezero/templates/operator/deployment.yaml
+++ b/charts/codezero/templates/operator/deployment.yaml
@@ -32,8 +32,14 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: CZ_ROUTER_PRIVILEGED_ACCESS
+            value: "{{ .Values.router.privilegedAccess }}"
           - name: CZ_ROUTER_REPLICAS
             value: "{{ .Values.router.replicas }}"
+          {{- with .Values.router.topologySpreadConstraints }}
+          - name: "CZ_ROUTER_TOPOLOGY_SPREAD_CONSTRAINTS"
+            value: {{ . | toJson | quote }}
+          {{- end }}
         securityContext:
           {{- toYaml .Values.operator.securityContext | nindent 12 }}
         livenessProbe:

--- a/charts/codezero/templates/spaceagent/deployment.yaml
+++ b/charts/codezero/templates/spaceagent/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       serviceAccountName: {{ include "spaceagent.name" . }}
       securityContext:
         {{- toYaml .Values.spaceagent.podSecurityContext | nindent 8 }}
+      {{- with .Values.spaceagent.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ include "spaceagent.name" . }}
           securityContext:
@@ -44,10 +48,6 @@ spec:
             - name: CZ_OPA_URL
               value: {{ .Values.opa.url }}
             {{- end }}
-            - name: CZ_ROUTER_IMAGE
-              value: "c6oio/router:{{ .Values.spaceagent.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
-            - name: CZ_ROUTER_PRIVILEGED_ACCESS
-              value: "{{ .Values.router.privilegedAccess }}"
             - name: CZ_TRACING_ENABLED
               value: "{{ .Values.tracing.enabled }}"
             - name: CZ_NAMESPACE

--- a/charts/codezero/values.yaml
+++ b/charts/codezero/values.yaml
@@ -25,6 +25,7 @@ podLabels: { }
 router:
   privilegedAccess: false
   replicas: 1
+  topologySpreadConstraints: []
 
 operator:
   name: operator
@@ -64,11 +65,11 @@ spaceagent:
   redis:
     secret: ""
 
-  podAnnotations: { }
-  labels: { }
-  podLabels: { }
+  podAnnotations: {}
+  labels: {}
+  podLabels: {}
 
-  podSecurityContext: { }
+  podSecurityContext: {}
   securityContext:
     runAsNonRoot: true
     runAsUser: 1000
@@ -80,14 +81,15 @@ spaceagent:
     seccompProfile:
       type: RuntimeDefault
 
-  resources: { }
-  nodeSelector: { }
-  tolerations: [ ]
-  affinity: { }
+  topologySpreadConstraints: []
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
   serviceAccount:
     create: true
-    annotations: { }
+    annotations: {}
     name: ""
 
 lb:
@@ -97,11 +99,11 @@ lb:
     pullPolicy: Always
   replicaCount: 1
 
-  podAnnotations: { }
-  labels: { }
-  podLabels: { }
+  podAnnotations: {}
+  labels: {}
+  podLabels: {}
 
-  podSecurityContext: { }
+  podSecurityContext: {}
   securityContext:
     runAsNonRoot: true
     runAsUser: 1000
@@ -113,16 +115,16 @@ lb:
     seccompProfile:
       type: RuntimeDefault
 
-  resources: { }
-  nodeSelector: { }
-  tolerations: [ ]
-  affinity: { }
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
   serviceAccount:
     create: true
-    annotations: { }
+    annotations: {}
     name: ""
 
   service:
-    annotations: { }
+    annotations: {}
     type: LoadBalancer


### PR DESCRIPTION
## Description

Allow setting `topologySpreadConstraints` for router and spaceagent. Remove unused envs on spaceagent.
