### PR TITLE
fix: have old lb annotations applied to space agent for forward compatability

### DIFF
--- a/charts/codezero/templates/spaceagent/service.yaml
+++ b/charts/codezero/templates/spaceagent/service.yaml
@@ -5,7 +5,11 @@ metadata:
   labels:
     {{- include "spaceagent.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.spaceagent.service.annotations }}
     {{ toYaml .Values.spaceagent.service.annotations | indent 4 | trim}}
+    {{- else if .Values.lb.service.annotations }}
+    {{ toYaml .Values.lb.service.annotations | indent 4 | trim}}
+    {{- end }}
 spec:
   type: {{ .Values.spaceagent.service.type }}
   {{- with .Values.spaceagent.service.loadBalancerIP }}


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

fixes #issue

You can also reference issues in other repos (including private repos)

fixes org/repo#issue
