### PR TITLE
chore: use default periodSeconds for probes

### DIFF
--- a/charts/codezero/templates/spaceagent/deployment.yaml
+++ b/charts/codezero/templates/spaceagent/deployment.yaml
@@ -96,15 +96,13 @@ spec:
               path: /healthz
               port: 8800
               scheme: HTTPS
-            initialDelaySeconds: 3
-            periodSeconds: 20
+            initialDelaySeconds: 1
           readinessProbe:
             httpGet:
               path: /readyz
               port: 8800
               scheme: HTTPS
-            initialDelaySeconds: 3
-            periodSeconds: 20
+            initialDelaySeconds: 1
           resources:
             {{- toYaml .Values.spaceagent.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
## Description

Reduce `initialDelaySeconds` and run with default `periodSeconds` (10s) for faster deployments.
